### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@master
+      uses: actions/checkout@v4.2.2
     - name: Run Repo File Sync Action
       uses: BetaHuhn/repo-file-sync-action@v1
       with:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@v4
     - name: Run Repo File Sync Action
       uses: BetaHuhn/repo-file-sync-action@v1
       with:

--- a/workflows/code-quality/codeql.yml
+++ b/workflows/code-quality/codeql.yml
@@ -16,10 +16,10 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.2.2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3.27.6
       with:
         languages: python
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3.27.6

--- a/workflows/code-quality/codeql.yml
+++ b/workflows/code-quality/codeql.yml
@@ -16,10 +16,10 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v4
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3.27.6
+      uses: github/codeql-action/init@v3
       with:
         languages: python
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3.27.6
+      uses: github/codeql-action/analyze@v3

--- a/workflows/code-quality/dependabot.yml
+++ b/workflows/code-quality/dependabot.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge minor/patch updates
-        uses: koj-co/dependabot-pr-action@master
+        uses: koj-co/dependabot-pr-action@v1.1.12
         with:
           token: ${{ secrets.GH_PAT }}
           merge-minor: true

--- a/workflows/code-quality/dependabot.yml
+++ b/workflows/code-quality/dependabot.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge minor/patch updates
-        uses: koj-co/dependabot-pr-action@v1.1.12
+        uses: koj-co/dependabot-pr-action@v1
         with:
           token: ${{ secrets.GH_PAT }}
           merge-minor: true

--- a/workflows/python/pre-commit.yml
+++ b/workflows/python/pre-commit.yml
@@ -10,8 +10,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
-    - uses: actions/setup-python@v5.3.0
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip'

--- a/workflows/python/pre-commit.yml
+++ b/workflows/python/pre-commit.yml
@@ -10,8 +10,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4.2.2
+    - uses: actions/setup-python@v5.3.0
       with:
         python-version: '3.x'
         cache: 'pip'

--- a/workflows/python/python-linting.yml
+++ b/workflows/python/python-linting.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4.2.2
+    - uses: actions/setup-python@v5.3.0
       with:
         python-version: '3.x'
         cache: 'pip'

--- a/workflows/python/python-linting.yml
+++ b/workflows/python/python-linting.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
-    - uses: actions/setup-python@v5.3.0
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip'

--- a/workflows/python/python-publish.yml
+++ b/workflows/python/python-publish.yml
@@ -9,9 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: '3.x'
         cache: 'pip'

--- a/workflows/python/python-publish.yml
+++ b/workflows/python/python-publish.yml
@@ -9,9 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v5.3.0
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip'

--- a/workflows/python/python-testing.yml
+++ b/workflows/python/python-testing.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.3.0
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/workflows/python/python-testing.yml
+++ b/workflows/python/python-testing.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5.3.0
       with:
@@ -30,7 +30,7 @@ jobs:
       run: |
         pytest --cov=./ --cov-report=xml --emoji
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5.1.1
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         fail_ci_if_error: true

--- a/workflows/python/python-testing.yml
+++ b/workflows/python/python-testing.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -30,7 +30,7 @@ jobs:
       run: |
         pytest --cov=./ --cov-report=xml --emoji
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5.1.1
       with:
         file: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[BetaHuhn/repo-file-sync-action](https://github.com/BetaHuhn/repo-file-sync-action)** published a new release **[v1.21.1](https://github.com/BetaHuhn/repo-file-sync-action/releases/tag/v1.21.1)** on 2024-05-05T12:03:16Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
