### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/workflows/code-quality/codeql.yml
+++ b/workflows/code-quality/codeql.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v3.29.3
       with:
         languages: python
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v3.29.3


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[v3.27.9](https://github.com/github/codeql-action/releases/tag/v3.27.9)** on 2024-12-12T23:12:28Z
